### PR TITLE
Gathering kindle formats right before extracting

### DIFF
--- a/action.py
+++ b/action.py
@@ -86,7 +86,8 @@ class InterfacePlugin(InterfaceAction):
         m = self.menu
         m.clear()
         kindle_formats = ['MOBI', 'AZW', 'AZW3', 'AZW4', 'PRC']
-        book_list = self.gatherKindleFormats([book_id], kindle_formats)
+        db = self.gui.library_view.model().db
+        book_list = gather_kindle_formats(db, book_id, kindle_formats)
         if not book_list:
             tool_tip = 'No suitable format to unpack.'
             error_menu = create_menu_item(self, m, _(tool_tip)+'...', None, _(tool_tip), None, None)
@@ -98,7 +99,7 @@ class InterfacePlugin(InterfaceAction):
             self.gui.keyboard.finalize()
             return
 
-        format_dict = book_list[0][2]
+        format_dict = book_list[1]
         for format in format_dict.keys():
             format_details = format_dict[format].get_format_details()
             # Weird and unlikely possiblity that there is no file on disk for this format at this point.
@@ -197,22 +198,6 @@ class InterfacePlugin(InterfaceAction):
         else:
             return choose_dir(self.gui, _(PLUGIN_NAME + 'dir_chooser'),
                 _('Select Directory To Unpack Kindle/Mobi Book To'))
-
-    def gatherKindleFormats(self, book_ids, target_formats, goal_format=None):
-        '''
-        Gathers all the kindle formats for the book(s) and uses the KindleFormats class
-        in utlities.py to collect details about each one. Including an initialized
-        mobiProcessor object.
-        '''
-        db = self.gui.library_view.model().db
-        books_info = []
-        for book_id in book_ids:
-            title = db.get_metadata(book_id, index_is_id=True, get_user_categories=False).title
-            book = KindleFormats(book_id, db, target_formats, goal_format)
-            details = book.get_formats()
-            if details:
-                books_info.append((book_id, title, details))
-        return books_info
 
     def multi_dispatcher(self, book_ids, target_format):
         '''

--- a/action.py
+++ b/action.py
@@ -229,10 +229,10 @@ class InterfacePlugin(InterfaceAction):
             goal_format = 'PDF'
             status_msg_type='Print Replica books'
             action_type='Extracting PDFs from'
-        books_info = self.gatherKindleFormats(book_ids, [target_format], goal_format)
+
         # If we have stuff ... send it on its way to the pretty ProgressDialog.
-        if books_info:
-            d = ProgressDialog(self.gui, books_info, self.extract_element, db, target_format, attr,
+        if goal_format:
+            d = ProgressDialog(self.gui, book_ids, self.extract_element, db, target_format, attr,
                                    status_msg_type=status_msg_type, action_type=action_type)
             if d.wasCanceled():
                 return

--- a/action.py
+++ b/action.py
@@ -26,8 +26,8 @@ from calibre_plugins.kindleunpack_plugin.__init__ import (PLUGIN_NAME,
 import calibre_plugins.kindleunpack_plugin.config as cfg
 from calibre_plugins.kindleunpack_plugin.dialogs import ProgressDialog, ResultsSummaryDialog
 # from calibre_plugins.kindleunpack_plugin.mobi_stuff import mobiProcessor
-from calibre_plugins.kindleunpack_plugin.utilities import (get_icon, KindleFormats, set_plugin_icon_resources,
-                                showErrorDlg, create_menu_item, create_menu_action_unique, build_log)
+from calibre_plugins.kindleunpack_plugin.utilities import (get_icon, set_plugin_icon_resources,
+                                showErrorDlg, create_menu_item, create_menu_action_unique, build_log, gather_kindle_formats)
 
 
 class InterfacePlugin(InterfaceAction):
@@ -38,9 +38,10 @@ class InterfacePlugin(InterfaceAction):
     # dont_add_to = frozenset(['menubar-device', 'toolbar-device', 'context-menu-device'])
     dont_add_to = frozenset(['context-menu-device'])
     action_type = 'current'
+    action_add_menu = True
 
     def genesis(self):
-        self.menu = QMenu(self.gui)
+        self.menu = self.qaction.menu()
         icon_resources = self.load_resources(cfg.PLUGIN_ICONS)
         set_plugin_icon_resources(cfg.PLUGIN_NAME, icon_resources)
 
@@ -101,7 +102,8 @@ class InterfacePlugin(InterfaceAction):
 
         format_dict = book_list[1]
         for format in format_dict.keys():
-            format_details = format_dict[format].get_format_details()
+            kindle_format_obj = format_dict[format]
+            format_details = kindle_format_obj.get_format_details()
             # Weird and unlikely possiblity that there is no file on disk for this format at this point.
             if format_details['errors'] is not None and format_details['errors'] == 'path':
                 tool_tip = 'No file on disk. Can\'t unpack.'
@@ -141,7 +143,7 @@ class InterfacePlugin(InterfaceAction):
             # Standard unpack to external folder ... disable menu if kindlebook encrypted.
             tool_tip = 'Unpack the {0}\'s source components'.format(format)
             unpack_menu = create_menu_action_unique(self, sm, _('Unpack')+' {0}'.format(format), 'images/explode3.png',
-                                                _(tool_tip), False, triggered=partial(self.unpack_ebook, kindle_obj))
+                                                _(tool_tip), False, triggered=partial(self.unpack_ebook, book_id, kindle_format_obj.format))
             if kindle_obj.isEncrypted:
                 unpack_menu.setEnabled(False)
 
@@ -149,20 +151,20 @@ class InterfacePlugin(InterfaceAction):
             if kindle_obj.isPrintReplica:
                 tool_tip = 'Extract the PDF from the Print Replica format and add it to the library.'
                 create_menu_action_unique(self, sm, _('Extract PDF')+'...', 'mimetypes/pdf.png', _(tool_tip), False,
-                                            triggered=partial(self.extract_element, kindle_obj, book_id, u'AZW4', False))
+                                            triggered=partial(self.extract_element, None, book_id, u'AZW4', False))
 
             # Offer to split kindlegen dual format output.
             if kindle_obj.isComboFile:
                 tool_tip = 'Split the combo KF8/MOBI file into its two components.'
                 create_menu_action_unique(self, sm, _('Split KF8/MOBI')+'...', 'edit-cut.png', _(tool_tip),
-                                            False, triggered=partial(self.combo_split, kindle_obj))
+                                            False, triggered=partial(self.combo_split, book_id, kindle_format_obj.format))
 
             # Extract ePub from the unpacked contents and add to current book's formats.
             convert_menu = None
             if kindle_obj.isKF8 or kindle_obj.isComboFile:
                 tool_tip = 'Convert standalone KF8 file to its original ePub.'
                 convert_menu = create_menu_action_unique(self, sm, _('KF8 to ePub')+'...', 'mimetypes/epub.png', _(tool_tip),
-                                            False, triggered=partial(self.extract_element, kindle_obj, book_id, u'AZW3', False))
+                                            False, triggered=partial(self.extract_element, None, book_id, u'AZW3', False))
             if kindle_obj.isEncrypted and convert_menu is not None:
                 convert_menu.setEnabled(False)
 
@@ -246,11 +248,15 @@ class InterfacePlugin(InterfaceAction):
         self.gui.library_view.select_rows(ids_to_highlight)
         return
 
-    def unpack_ebook(self, kindle_obj):
+    def unpack_ebook(self, book_id, target_format):
         '''
         Unpack kindlebook to external folder.
         '''
         outdir = self.directoryChooser()
+        db = self.gui.library_view.model().db
+        ignore, details = gather_kindle_formats(db, book_id, target_format)
+        kindle_obj = details[target_format].get_format_details()['kindle_obj']
+
         if outdir:
             try:
                 kindle_obj.unpackMOBI(outdir)
@@ -264,6 +270,12 @@ class InterfacePlugin(InterfaceAction):
         '''
         outdir = PersistentTemporaryDirectory()
         errmsg = ''
+
+        if kindle_obj is None:
+            db = self.gui.library_view.model().db
+            ignore, details = gather_kindle_formats(db, book_id, target)
+            kindle_obj = details[target].get_format_details()['kindle_obj']
+
         if target == 'AZW3':
             errmsg = 'An'
             format = 'EPUB'
@@ -302,11 +314,15 @@ class InterfacePlugin(InterfaceAction):
             return False, errmsg
         return showErrorDlg(errmsg, self.gui)
 
-    def combo_split(self, kindle_obj):
+    def combo_split(self, book_id, target_format):
         '''
         Split kindlegen output into its AZW3/MOBI pieces.
         '''
         outdir = self.directoryChooser()
+        db = self.gui.library_view.model().db
+        ignore, details = gather_kindle_formats(db, book_id, target_format)
+        kindle_obj = details[target_format].get_format_details()['kindle_obj']
+
         if outdir:
             try:
                 kindle_obj.writeSplitCombo(outdir)

--- a/dialogs.py
+++ b/dialogs.py
@@ -18,7 +18,7 @@ except ImportError:
 
 from calibre.gui2.dialogs.message_box import MessageBox
 from calibre_plugins.kindleunpack_plugin.__init__ import (PLUGIN_NAME, PLUGIN_VERSION)
-from calibre_plugins.kindleunpack_plugin.utilities import KindleFormats
+from calibre_plugins.kindleunpack_plugin.utilities import KindleFormats, gather_kindle_formats
 
 class ProgressDialog(QProgressDialog):
     '''
@@ -52,7 +52,7 @@ class ProgressDialog(QProgressDialog):
         book_id = self.book_ids[self.i]
         self.i += 1
 
-        dtitle, format_dict = self.gather_kindle_formats(book_id, self.target_format, self.goal)
+        dtitle, format_dict = gather_kindle_formats(self.db, book_id, self.target_format, self.goal)
 
         all_formats = self.db.formats(book_id, index_is_id=True, verify_formats=True)
         if all_formats is not None:
@@ -94,20 +94,6 @@ class ProgressDialog(QProgressDialog):
         self.setValue(self.i)
 
         QTimer.singleShot(0, self.do_multiple_book_action)
-
-
-    def gather_kindle_formats(self, book_id, target_format, goal_format=None):
-        '''
-        Gathers all the kindle formats for the book and uses the KindleFormats class
-        in utlities.py to collect details. Including an initialized mobiProcessor object.
-        '''
-        title = self.db.get_metadata(book_id, index_is_id=True, get_user_categories=False).title
-        book = KindleFormats(book_id, self.db, [target_format], goal_format)
-        details = book.get_formats()
-        if details:
-            return (title, details)
-
-        return None
 
     def do_close(self):
         self.hide()

--- a/utilities.py
+++ b/utilities.py
@@ -229,6 +229,22 @@ class KindleFormatDetails:
         self.__details['kindle_obj'] = mobi
         return self.__details
 
+
+def gather_kindle_formats(db, book_id, target_format, goal_format=None):
+    '''
+    Gathers all the kindle formats for the book and uses the KindleFormats class
+    in utlities.py to collect details. Including an initialized mobiProcessor object.
+    '''
+    title = db.get_metadata(book_id, index_is_id=True, get_user_categories=False).title
+    target_formats = target_format if isinstance(target_format, list) else [target_format]
+    book = KindleFormats(book_id, db, target_formats, goal_format)
+    details = book.get_formats()
+    if details:
+        return (title, details)
+
+    return None
+
+
 def build_log(failures, successes, target, goal, name):
     NOFORMAT = ENCRYPTED = NOSPECIAL = UNKNOWN = EXISTS = 0
     NOFORMAT_titles, ENCRYPTED_titles, NOSPECIAL_titles, UNKNOWN_titles, EXISTS_titles = [], [], [], [], []


### PR DESCRIPTION
I use Calibre on a 2GB RAM Synology NAS machine, the plugin consumed 800MB (or more) extra RAM while was converting hundreds of large AZW3 books. So before the plugin finishing the task, Docker killed Calibre for memory exhausted.

This patch postpones kindle formats gathering, the `def multi_dispatcher()` no need to hold large number of huge size `kindle_obj`s, and plugin's memory usage down to 100~200MB on batch converting.